### PR TITLE
Add support for Business Pro versions 1.0.0 to 1.0.4

### DIFF
--- a/genesis-title-toggle.php
+++ b/genesis-title-toggle.php
@@ -370,6 +370,10 @@ class BE_Title_Toggle {
 				remove_action( 'genesis_before_content_sidebar_wrap', 'genesis_do_post_title' );
 				break;
 
+			case 'Business Pro':
+				remove_action( 'genesis_after_header', 'business_page_header_title', 24 );
+				break;
+
 			case 'Business Pro Theme':
 				remove_action( 'business_page_header', 'business_page_title', 10 );
 				break;


### PR DESCRIPTION
Instead of checking for the theme version, we can just use a different theme name since older versions of Business Pro (1.0.0 to 1.0.4) used the name _'Business Pro'_ instead of _'Business Pro Theme'_. This was changed because of a naming conflict with another theme in the WordPress.org repository.